### PR TITLE
feat: generate robots.txt and sitemap.xml based on version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,18 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@a4u/a4u-collection-react-spectrum-open-source-color-icons-release": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-a4u-release/@a4u/a4u-collection-react-spectrum-open-source-color-icons-release/-/@a4u/a4u-collection-react-spectrum-open-source-color-icons-release-2.0.0.tgz",
+      "integrity": "sha1-kv4I7ZfYfM7FqxXKIdqOjqqlifo=",
+      "optional": true
+    },
+    "@a4u/a4u-collection-react-spectrum-open-source-release": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-a4u-release/@a4u/a4u-collection-react-spectrum-open-source-release/-/@a4u/a4u-collection-react-spectrum-open-source-release-3.1.0.tgz",
+      "integrity": "sha1-Od7TCVxEykInNvf1+5HcBmcLsWM=",
+      "optional": true
+    },
     "@a4u/a4u-collection-spectrum-css-release": {
       "version": "2.2.0",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-a4u-release-local/@a4u/a4u-collection-spectrum-css-release/-/@a4u/a4u-collection-spectrum-css-release-2.2.0.tgz",
@@ -20,6 +32,8 @@
       "resolved": "https://registry.npmjs.org/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.0.0-beta.6.tgz",
       "integrity": "sha512-jqJ8wATVN57MHnckPpI/SXfUUUoOUgqjvOMv0cn7dYd83c0IrPNyExJ1u5aCs0B4LpP4A5k7TBAeoZ1VNU6rUw==",
       "requires": {
+        "@a4u/a4u-collection-react-spectrum-open-source-color-icons-release": "^2.0.0",
+        "@a4u/a4u-collection-react-spectrum-open-source-release": "^3.0.0",
         "@a4u/a4u-collection-spectrum-css-release": "^2.1.0"
       }
     },
@@ -3943,6 +3957,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -6741,6 +6761,15 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "nextjs-sitemap-generator": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/nextjs-sitemap-generator/-/nextjs-sitemap-generator-0.1.1.tgz",
+      "integrity": "sha512-oNPQpVSxNjPGSYDTM/UBLa7QzJjo5Dq7Rh4Sgupfm2DJRNdo6zR6FOHU939em37yccWU8qSpWqFllrrLVOSWTQ==",
+      "dev": true,
+      "requires": {
+        "date-fns": "^1.30.1"
+      }
     },
     "node-fetch": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "next",
     "build": "next build",
     "export": "next build && next export -o spectrum-css",
+    "postexport": "node sitemap_generator",
     "prep": "npm run build && npm run export && touch spectrum-css/.nojekyll",
     "deploy": "git subtree push --prefix spectrum-css origin gh-pages"
   },
@@ -50,6 +51,7 @@
     "glob": "^7.1.4",
     "js-yaml": "^3.13.1",
     "lunr": "^2.3.6",
+    "nextjs-sitemap-generator": "^0.1.1",
     "node-sass": "^4.12.0",
     "react-helmet": "^5.2.1",
     "webpack": "^4.39.3",

--- a/sitemap_generator.js
+++ b/sitemap_generator.js
@@ -1,0 +1,16 @@
+const sitemap=require('nextjs-sitemap-generator');
+const version=require('./package').version;
+const fs = require('fs');
+
+sitemap({
+  baseUrl: `https://opensource.adobe.com/spectrum-css/${version}/docs`,
+  pagesDirectory: './spectrum-css/components/',
+  targetDirectory : './spectrum-css/static/'
+});
+
+fs.writeFileSync('./spectrum-css/robots.txt', `# All robots allowed
+User-agent: *
+Disallow:
+
+# Sitemap files
+Sitemap: https://opensource.adobe.com/spectrum-css/${version}/docs/static/sitemap.xml`);


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
A npm script run after `export`. It will generate the `robots.txt` and `sitemap.xml` based on the current version number in package.json.

Here I'm assuming that the export static site content will be deployed to a server which can be accessed by the url like this: `https://opensource.adobe.com/spectrum-css/${version}/docs`.

`robots.txt` will need to be deployed to a folder that can be accessed by `https://opensource.adobe.com/robots.txt`.

## How and where has this been tested?

 - How this was tested: <!-- Using steps in issue #000 -->
 - Browser(s) and OS(s) this was tested with: <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [x] This pull request is ready to merge.
