### PR TITLE
fix: set correct base url for sitemap generation

### DIFF
--- a/sitemap_generator.js
+++ b/sitemap_generator.js
@@ -1,16 +1,7 @@
 const sitemap=require('nextjs-sitemap-generator');
-const version=require('./package').version;
-const fs = require('fs');
 
 sitemap({
-  baseUrl: `https://opensource.adobe.com/spectrum-css/${version}/docs`,
+  baseUrl: 'https://opensource.adobe.com/spectrum-css',
   pagesDirectory: './spectrum-css/components/',
   targetDirectory : './spectrum-css/static/'
 });
-
-fs.writeFileSync('./spectrum-css/robots.txt', `# All robots allowed
-User-agent: *
-Disallow:
-
-# Sitemap files
-Sitemap: https://opensource.adobe.com/spectrum-css/${version}/docs/static/sitemap.xml`);


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
1. Use `opensource.adobe.com/spectrum-css` as base url for sitemap.
2. Remove robots.txt generation

Robots.txt generation here is useless. All we need to is just referencing our `sitemap.xml` from the `robots.txt` in the domain root as below. According to robots.txt [specification](https://technicalseo.com/tools/docs/robots-txt/), it supports multiple sitemap references. We can just hard code and leave it there.

Example:
```
Sitemap: https://opensource.adobe.com/spectrum-css/static/sitemap.xml
```


## How and where has this been tested?

 - How this was tested: <!-- Using steps in issue #000 -->
 - Browser(s) and OS(s) this was tested with: <!-- Chrome 75.0.3770.142 on Win 10 -->

## Screenshots
<!-- If applicable, add screenshots to show what you changed -->


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [ ] If my change impacts other components, I have tested to make sure they don't break.
- [ ] If my change impacts documentation, I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaning tasks here -->
- [ ] This pull request is ready to merge.
